### PR TITLE
Fix how server.js handles the PORT environment variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const express = require("express");
 const mongoose = require("mongoose");
 require("dotenv").config();
 
-const PORT = process.env.PORT | 3000;
+const PORT = process.env.PORT || 3000;
 const DB_STRING = process.env.DB_STRING;
 
 // Initialize Express


### PR DESCRIPTION
Previously, it used the `|` symbol, short for bitwise or: this is probably a typo, so this commit fixes it by making it use the `||` symbol